### PR TITLE
Fix hiredis and express-session

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ sessionMiddleware = session({
     store: new RedisStore({
         client: client
     }),
-    secret: 'blibble'
+    secret: 'blibble',
+    resave: true,
+    saveUninitialized: true
 });
 app.use(sessionMiddleware);
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.10.4",
     "express-session": "^1.10.2",
     "hbs": "^2.7.0",
-    "hiredis": "^0.1.17",
+    "hiredis": "^0.5.0",
     "morgan": "^1.6.1",
     "redis": "^0.12.1",
     "socket.io": "^1.2.1",


### PR DESCRIPTION
Two commits in this patch.

- The first updates hiredis to the latest version (0.5.0), to avoid errors occurring when `npm install` with new node versions.
- The second fixes #1 in the way that @nurettinbakkal suggested.